### PR TITLE
Implement Flag for allowing tethering mode to work with CIQ simulator 

### DIFF
--- a/watch_connectivity_garmin/android/src/main/kotlin/dev/rexios/watch_connectivity_garmin/WatchConnectivityGarminPlugin.kt
+++ b/watch_connectivity_garmin/android/src/main/kotlin/dev/rexios/watch_connectivity_garmin/WatchConnectivityGarminPlugin.kt
@@ -36,7 +36,6 @@ class WatchConnectivityGarminPlugin : FlutterPlugin, MethodCallHandler {
         context = flutterPluginBinding.applicationContext
 
         packageManager = context.packageManager
-        connectIQ = ConnectIQ.getInstance(context, ConnectIQ.IQConnectType.WIRELESS)
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
@@ -64,6 +63,10 @@ class WatchConnectivityGarminPlugin : FlutterPlugin, MethodCallHandler {
         val applicationId = call.argument<String>("applicationId")!!
         iqApp = IQApp(applicationId)
 
+        val isTethered = call.argument<Boolean>("tethered")!!
+        var connectType = ConnectIQ.IQConnectType.WIRELESS
+        if (isTethered) connectType = ConnectIQ.IQConnectType.TETHERED
+        connectIQ = ConnectIQ.getInstance(context, connectType)
         connectIQ.initialize(
             context,
             call.argument<Boolean>("autoUI")!!,

--- a/watch_connectivity_garmin/lib/src/garmin_initialization_options.dart
+++ b/watch_connectivity_garmin/lib/src/garmin_initialization_options.dart
@@ -9,11 +9,15 @@ class GarminInitializationOptions {
   /// Show UI to help the user resolve issues with Garmin Connect
   final bool autoUI;
 
+  /// Tethering mode is set for connectivity with Garmin Connect.
+  final bool tethered;
+
   /// Constructor
   GarminInitializationOptions({
     required this.applicationId,
     required this.urlScheme,
     this.autoUI = false,
+    this.tethered = false,
   });
 
   /// Convert to JSON
@@ -21,5 +25,6 @@ class GarminInitializationOptions {
         'applicationId': applicationId,
         'urlScheme': urlScheme,
         'autoUI': autoUI,
+        'tethered': tethered,
       };
 }


### PR DESCRIPTION
Added flag for choosing between `ConnectIQ.IQConnectType.WIRELESS` and `ConnectIQ.IQConnectType.TETHERED` when initializing ConnectIQ.  Defaults to `WIRELESS`