### PR TITLE
fix(iOS): isPaired returns correct state after watch switch

### DIFF
--- a/watch_connectivity/ios/Classes/SwiftWatchConnectivityPlugin.swift
+++ b/watch_connectivity/ios/Classes/SwiftWatchConnectivityPlugin.swift
@@ -61,7 +61,9 @@ public class SwiftWatchConnectivityPlugin: NSObject, FlutterPlugin, WCSessionDel
     
   public func sessionDidBecomeInactive(_ session: WCSession) {}
     
-  public func sessionDidDeactivate(_ session: WCSession) {}
+  public func sessionDidDeactivate(_ session: WCSession) {
+    session.activate()
+  }
     
   public func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {
     DispatchQueue.main.async {


### PR DESCRIPTION
This PR fixes a bug where `isPaired` returns `false` and doesn't update to `true` after a user switches to a different active watch.


## Problem

When multiple Apple Watches are paired with an iPhone and a user switches the active watch (e.g., from a Series 8 to an Ultra), the `WCSession` on the iOS side enters an deactivated state. 
 - source document: https://developer.apple.com/documentation/watchconnectivity/wcsession#Supporting-Communication-with-Multiple-Apple-Watches


This plugin does not properly handle this state transition, causing `isPaired` to remain false even after a new session is activated.


## Solution

This fix adds a call to `session.activate()` within the `sessionDidDeactivate(_:)` delegate method. This ensures that the session is reactivated after it becomes inactive.

Since `session` represents the communication session (pathway) rather than the connection status, it is unnecessary to wait until pairing is complete.


## Testing

To verify this fix, you can:

1. Pair two different Apple Watches (e.g., Watch A and Watch B) with an iPhone.
2. Open the iOS Watch app on the iPhone and select Watch A.
3. Confirm that the isPaired state in your Flutter app is true.
4. In the iOS Watch app, switch the active watch to Watch B.
5. Verify that isPaired temporarily becomes false and then updates back to true.
