### PR TITLE
Migrate to built-in Kotlin

### DIFF
--- a/watch_connectivity/CHANGELOG.md
+++ b/watch_connectivity/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.9
+
+- Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.
+- Migrates to built-in Kotlin
+
 ## 0.2.8
 
 - Supports SwiftPM

--- a/watch_connectivity/android/build.gradle
+++ b/watch_connectivity/android/build.gradle
@@ -2,7 +2,6 @@ group 'dev.rexios.watch_connectivity'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.7.20'
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:7.3.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -22,7 +20,6 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 36
@@ -30,10 +27,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = '1.8'
     }
 
     sourceSets {
@@ -46,8 +39,12 @@ android {
     namespace "dev.rexios.watch_connectivity"
 }
 
-dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
+    }
+}
 
+dependencies {
     api 'com.google.android.gms:play-services-wearable:19.0.0'
 }

--- a/watch_connectivity/example/android/app/build.gradle
+++ b/watch_connectivity/example/android/app/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "com.android.application"
-    id "kotlin-android"
     id "dev.flutter.flutter-gradle-plugin"
 }
 
@@ -29,10 +28,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
@@ -54,6 +49,12 @@ android {
         }
     }
     namespace 'dev.rexios.watch_connectivity_example'
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
+    }
 }
 
 flutter {

--- a/watch_connectivity/example/android/gradle.properties
+++ b/watch_connectivity/example/android/gradle.properties
@@ -4,3 +4,5 @@ android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+android.newDsl=false
+android.builtInKotlin=false

--- a/watch_connectivity/example/android/gradle.properties
+++ b/watch_connectivity/example/android/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx2048m
+org.gradle.jvmargs=-Xmx4G
 android.useAndroidX=true
 android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true

--- a/watch_connectivity/example/pubspec.lock
+++ b/watch_connectivity/example/pubspec.lock
@@ -207,10 +207,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -223,10 +223,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   package_config:
     dependency: transitive
     description:
@@ -324,10 +324,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.8"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:
@@ -366,14 +366,14 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.7"
+    version: "0.2.9"
   watch_connectivity_garmin:
     dependency: "direct main"
     description:
       path: "../../watch_connectivity_garmin"
       relative: true
     source: path
-    version: "0.1.11"
+    version: "0.1.13"
   watch_connectivity_platform_interface:
     dependency: "direct overridden"
     description:
@@ -406,5 +406,5 @@ packages:
     source: hosted
     version: "2.2.3"
 sdks:
-  dart: ">=3.10.0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/watch_connectivity/pubspec.yaml
+++ b/watch_connectivity/pubspec.yaml
@@ -1,11 +1,11 @@
 name: watch_connectivity
 description: Wrapper for WatchConnectivity on iOS and Wearable APIs on Android
-version: 0.2.8
+version: 0.2.9
 homepage: https://github.com/Rexios80/watch_connectivity/tree/master/watch_connectivity
 
 environment:
-  sdk: ">=2.15.1 <4.0.0"
-  flutter: ">=2.5.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:

--- a/watch_connectivity_garmin/CHANGELOG.md
+++ b/watch_connectivity_garmin/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.13
+
+- Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.
+- Migrates to built-in Kotlin
+
 ## 0.1.12
 
 - Supports SwiftPM

--- a/watch_connectivity_garmin/android/build.gradle
+++ b/watch_connectivity_garmin/android/build.gradle
@@ -2,7 +2,6 @@ group 'dev.rexios.watch_connectivity_garmin'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.7.20'
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:7.3.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -22,7 +20,6 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 36
@@ -30,10 +27,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = '1.8'
     }
 
     sourceSets {
@@ -46,7 +39,12 @@ android {
     namespace "dev.rexios.watch_connectivity_garmin"
 }
 
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
+    }
+}
+
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.garmin.connectiq:ciq-companion-app-sdk:2.0.3@aar'
 }

--- a/watch_connectivity_garmin/lib/src/garmin_initialization_options.dart
+++ b/watch_connectivity_garmin/lib/src/garmin_initialization_options.dart
@@ -35,12 +35,12 @@ class GarminInitializationOptions {
 
   /// Convert to JSON
   Map<String, dynamic> toJson() => {
-        'applicationId': applicationId,
-        'urlScheme': urlScheme,
-        'autoUI': autoUI,
-        'connectType': connectType.name.constantCase,
-        'adbPort': adbPort,
-      };
+    'applicationId': applicationId,
+    'urlScheme': urlScheme,
+    'autoUI': autoUI,
+    'connectType': connectType.name.constantCase,
+    'adbPort': adbPort,
+  };
 }
 
 /// Enum for type of Garmin connection to establish
@@ -49,5 +49,5 @@ enum GarminIqConnectionType {
   tethered,
 
   /// Wireless connection
-  wireless;
+  wireless,
 }

--- a/watch_connectivity_garmin/pubspec.yaml
+++ b/watch_connectivity_garmin/pubspec.yaml
@@ -1,11 +1,11 @@
 name: watch_connectivity_garmin
 description: Wrapper for the ConnectIQ SDK to communicate with Garmin watches
-version: 0.1.12
+version: 0.1.13
 homepage: https://github.com/Rexios80/watch_connectivity/tree/master/watch_connectivity_garmin
 
 environment:
-  sdk: ">=2.17.1 <4.0.0"
-  flutter: ">=2.5.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary
- Migrates `watch_connectivity` and `watch_connectivity_garmin` to built-in Kotlin: removes the explicit Kotlin Gradle Plugin usage (`apply plugin: 'kotlin-android'`, the `kotlin-gradle-plugin` buildscript classpath, `ext.kotlin_version`, and the explicit `kotlin-stdlib` dependency) and adds a `kotlin { compilerOptions { jvmTarget = ... } }` block.
- Raises minimum SDK to Flutter 3.44 / Dart 3.12, patch-bumps both package versions, and adds CHANGELOG entries.
- Migrates the `watch_connectivity` example app per the [app-developer guide](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers) (adds `android.builtInKotlin=false` / `android.newDsl=false`, removes the `kotlin-android` plugin + `kotlinOptions`). No AGP upgrade. (`watch_connectivity_garmin` has no example app.)

See the [plugin-author migration guide](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors).

## Test plan
- [ ] CI passes
- [ ] Example builds after the separate AGP 9 upgrade

Made with [Cursor](https://cursor.com)