### PR TITLE
Restore pub points by removing unnecessary library names

### DIFF
--- a/watch_connectivity/CHANGELOG.md
+++ b/watch_connectivity/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.10
+
+- Removes unnecessary library names
+
 ## 0.2.9
 
 - Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.

--- a/watch_connectivity/lib/watch_connectivity.dart
+++ b/watch_connectivity/lib/watch_connectivity.dart
@@ -1,5 +1,3 @@
-library watch_connectivity;
-
 export 'package:watch_connectivity_platform_interface/watch_connectivity_platform_interface.dart';
 
 export 'src/watch_connectivity_base.dart';

--- a/watch_connectivity/pubspec.yaml
+++ b/watch_connectivity/pubspec.yaml
@@ -1,6 +1,6 @@
 name: watch_connectivity
 description: Wrapper for WatchConnectivity on iOS and Wearable APIs on Android
-version: 0.2.9
+version: 0.2.10
 homepage: https://github.com/Rexios80/watch_connectivity/tree/master/watch_connectivity
 
 environment:

--- a/watch_connectivity_garmin/CHANGELOG.md
+++ b/watch_connectivity_garmin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.14
+
+- Removes unnecessary library names
+
 ## 0.1.13
 
 - Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.

--- a/watch_connectivity_garmin/lib/watch_connectivity_garmin.dart
+++ b/watch_connectivity_garmin/lib/watch_connectivity_garmin.dart
@@ -1,5 +1,3 @@
-library watch_connectivity_garmin;
-
 export 'package:watch_connectivity_platform_interface/watch_connectivity_platform_interface.dart';
 
 export 'src/garmin_initialization_options.dart';

--- a/watch_connectivity_garmin/pubspec.yaml
+++ b/watch_connectivity_garmin/pubspec.yaml
@@ -1,6 +1,6 @@
 name: watch_connectivity_garmin
 description: Wrapper for the ConnectIQ SDK to communicate with Garmin watches
-version: 0.1.13
+version: 0.1.14
 homepage: https://github.com/Rexios80/watch_connectivity/tree/master/watch_connectivity_garmin
 
 environment:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`watch_connectivity` 0.2.9 and `watch_connectivity_garmin` 0.1.13 dropped from 160 to 150 pub points because pana now treats the `unnecessary_library_name` INFO lint as a 10-point analysis deduction.

Both barrel files declared unused named `library` directives (`library watch_connectivity;` / `library watch_connectivity_garmin;`). Those names are not referenced by `part` files or imports, so the directives are removed entirely (a bare `library;` would still trip `unnecessary_library_directive`).

Patch versions are bumped so the fix can be published:

- `watch_connectivity` 0.2.9 → 0.2.10
- `watch_connectivity_garmin` 0.1.13 → 0.1.14

`watch_connectivity_platform_interface` is unchanged: it still scores 160/160 (older SDK language version, so this lint is not applied).

## Test plan

- [x] `dart analyze` is clean in both packages
- [x] Local `pana --no-warning --exit-code-threshold 0` (pana 0.23.19, Flutter 3.47.2 / Dart 3.13.2) reports **50/50 analysis and 160/160 overall** for both packages
- [x] CI static-analysis workflow passes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a33aaae6-a91e-4510-907b-eaf9612dbfb3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a33aaae6-a91e-4510-907b-eaf9612dbfb3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

